### PR TITLE
Use encoding/json

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/k1LoW/grpcstub
 go 1.18
 
 require (
-	github.com/goccy/go-json v0.9.8
 	github.com/golang/protobuf v1.5.2
 	github.com/jhump/protoreflect v1.12.0
 	github.com/mattn/go-jsonpointer v0.0.1

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,6 @@ github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymF
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210217033140-668b12f5399d/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/goccy/go-json v0.9.8 h1:DxXB6MLd6yyel7CLph8EwNIonUtVZd3Ue5iRcL4DQCE=
-github.com/goccy/go-json v0.9.8/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=

--- a/grpcstub.go
+++ b/grpcstub.go
@@ -2,6 +2,7 @@ package grpcstub
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"net"
@@ -12,7 +13,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/goccy/go-json"
 	"github.com/golang/protobuf/proto" //nolint
 	"github.com/jhump/protoreflect/desc"
 	"github.com/jhump/protoreflect/desc/protoparse"


### PR DESCRIPTION
🤔 

```
panic: runtime error: index out of range [43276] with length 43276

goroutine 36 [running]:
github.com/goccy/go-json/internal/encoder.CompileToGetCodeSet(0x140000b77b8?, 0x102b8b1a8?)
        /Users/k1low/go/pkg/mod/github.com/goccy/go-json@v0.9.8/internal/encoder/compiler_norace.go:15 +0x1f4
github.com/goccy/go-json.encode(0x1400052e8f0, {0x1036ebf00, 0x140005bad50})
        /Users/k1low/go/pkg/mod/github.com/goccy/go-json@v0.9.8/encode.go:226 +0xe8
github.com/goccy/go-json.marshal({0x1036ebf00, 0x140005bad50}, {0x0, 0x0, 0x14000192701?})
        /Users/k1low/go/pkg/mod/github.com/goccy/go-json@v0.9.8/encode.go:150 +0xbc
github.com/goccy/go-json.MarshalWithOption(...)
        /Users/k1low/go/pkg/mod/github.com/goccy/go-json@v0.9.8/json.go:186
github.com/goccy/go-json.Marshal({0x1036ebf00?, 0x140005bad50?})
        /Users/k1low/go/pkg/mod/github.com/goccy/go-json@v0.9.8/json.go:171 +0x34
github.com/k1LoW/grpcstub.(*Server).createUnaryHandler.func1({0x1036f9280?, 0x1400061c2a0?}, {0x1036f9280, 0x140005bacc0}, 0x140000aeae0, 0x140006ba120?)
        /Users/k1low/src/github.com/k1LoW/grpcstub/grpcstub.go:412 +0x11c
google.golang.org/grpc.(*Server).processUnaryRPC(0x140003796c0, {0x1036fd7a8, 0x14000192780}, 0x140006ba120, 0x14000331050, 0x1400049f608, 0x0)
        /Users/k1low/go/pkg/mod/google.golang.org/grpc@v1.42.0/server.go:1282 +0xb3c
google.golang.org/grpc.(*Server).handleStream(0x140003796c0, {0x1036fd7a8, 0x14000192780}, 0x140006ba120, 0x0)
        /Users/k1low/go/pkg/mod/google.golang.org/grpc@v1.42.0/server.go:1616 +0x840
google.golang.org/grpc.(*Server).serveStreams.func1.2()
        /Users/k1low/go/pkg/mod/google.golang.org/grpc@v1.42.0/server.go:921 +0x88
created by google.golang.org/grpc.(*Server).serveStreams.func1
        /Users/k1low/go/pkg/mod/google.golang.org/grpc@v1.42.0/server.go:919 +0x298
```